### PR TITLE
fix(ci): update Go matrix to 1.25/1.26, pin golangci-lint v2.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   test:
@@ -82,7 +82,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
+        version: v2.9.0
         args: --timeout=5m
 
   security:
@@ -221,7 +221,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go-version: ['1.24', '1.25']
+        go-version: ['1.25', '1.26']
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
CI matrix was behind org standard (1.24/1.25) and golangci-lint used unpinned `latest`. Updated to Go 1.25/1.26 and pinned golangci-lint v2.9.0 to match 1mb-dev org standards.